### PR TITLE
Update docs to describe difference between pyyaml and ryaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,20 @@ ryaml
 
 ryaml is a Python library that wraps a Rust yaml parser, [serde-yaml](https://github.com/dtolnay/serde-yaml), to quickly and safely parse and dump yaml to and from Python objects.
 
-It is *not* compatible with PyYAML, but has a similar design to the `json` module.
+It is *not* compatible with PyYAML, and it has a similar design to the `json` module. Furthermore PyYAML implements version 1.1 of the yaml spec whereas ryaml implements version 1.2 of the spec.
+
+Notable differences between version 1.1 and 1.2 are
+
+- YAML 1.2 dropped support for several features unquoted `Yes`,
+  `No`, `On`, `Off`
+- YAML 1.2 no longer accepts strings that start with a `0` and solely
+  consist of number characters as octal, you need to specify such strings with
+  `0o[0-7]+` (zero + lower-case o for octal + one or more octal characters).
+- YAML 1.2 no longer supports `sexagesimals
+  <https://en.wikipedia.org/wiki/Sexagesimal>`_, so the string scalar
+  `12:34:56` doesn't need quoting.
+- `\/` escape for JSON compatibility
+- correct parsing of floating point scalars with exponentials
 
 The hope is this will be used as a safe and fast yaml parser in lieu of PyYAML.
 


### PR DESCRIPTION
There are some crucial differences between pyyaml and ryaml which should be described as they implement different versions of the yaml spec. 

The differences is also described in another python package that implements the 1.2 version of the spec. 
https://yaml.readthedocs.io/en/latest/pyyaml.html#defaulting-to-yaml-1-2-support

closes #3 