### PR TITLE
Exclude pyodide from PyPI uploads

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/download-artifact@v5
         with:
           # unpacks all CIBW artifacts except pyodide into dist/
-          pattern: !cibw-wheels-pyodide-*
+          pattern: "!cibw-wheels-pyodide-*"
           path: dist
           merge-multiple: true
 


### PR DESCRIPTION
Update artifact download pattern to exclude pyodide wheels.