### PR TITLE
Remove skip-existing from PyPI upload action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -131,5 +131,3 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true


### PR DESCRIPTION
This was a one-time workaround we should remove now.